### PR TITLE
Correct misspelling/bad phrasing on failure reports

### DIFF
--- a/lib/rcov/formatters/failure_report.rb
+++ b/lib/rcov/formatters/failure_report.rb
@@ -4,11 +4,11 @@ module Rcov
       puts summary
       coverage = code_coverage * 100
       if coverage < @failure_threshold
-        puts "You failed to satisfy the coverage theshold of #{@failure_threshold}%"
+        puts "You failed to satisfy the coverage threshold of #{@failure_threshold}%."
         exit(1)
       end
       if (coverage - @failure_threshold) > 3
-        puts "Your coverage has significantly increased over your threshold of #{@failure_threshold}. Please increase it."
+        puts "Your coverage is close to your threshold of #{@failure_threshold}. Please increase it."
       end
     end
   end


### PR DESCRIPTION
Patch should be self-explanatory. Just some minor cleanup on the inaccurate phrasing and misspelling in failure report messages.
