### PR TITLE
Fix invalid byte sequence in us ascii

### DIFF
--- a/lib/rcov/file_statistics.rb
+++ b/lib/rcov/file_statistics.rb
@@ -110,6 +110,7 @@ module Rcov
         pending = []
         state = :code
         @lines.each_with_index do |line, index|
+          line.force_encoding("utf-8")
           case state
           when :code
             if /^=begin\b/ =~ line


### PR DESCRIPTION
Hi,

I fixed relevance/rcov#31 to work with ruby 1.9.

Cheers,
Alex
