### PR TITLE
Vanilla ruby missing jruby version

### DIFF
--- a/lib/rcov/code_coverage_analyzer.rb
+++ b/lib/rcov/code_coverage_analyzer.rb
@@ -264,6 +264,7 @@ module Rcov
         end
         SCRIPT_LINES__[file] = lines
       end
+    rescue NameError
     end
 
     public


### PR DESCRIPTION
Fix for a bug in the master branch which prevents rcov from running under vanilla Ruby (JRUBY_VERSION is not defined).
