### PR TITLE
Custom formatters

### DIFF
--- a/bin/rcov
+++ b/bin/rcov
@@ -27,6 +27,7 @@ options.profiling = false
 options.destdir = nil
 options.loadpaths = []
 options.textmode = false
+options.custom_formatters = []
 options.skip = Rcov::BaseFormatter::DEFAULT_OPTS[:ignore]
 options.include = []
 options.html = true
@@ -177,6 +178,17 @@ EOF
   
   opts.on("--text-coverage", "Dump coverage info to stdout, using", "ANSI color sequences unless -n.") do
     options.textmode = :coverage
+  end
+
+  opts.on("--custom-formatter EXPR", "Generate additional output using a",
+          "custom formatter class. The expression",
+		  "is evaluated as Ruby code and should",
+          "return a Class object") do |class_expr|
+    formatter = instance_eval class_expr
+    unless formatter.is_a? Class
+      raise "--custom-formatter expression must return a Class object. Got a #{formatter.class.name}"
+    end
+    options.custom_formatters << formatter
   end
   
   opts.on("--gcc", "Dump uncovered line in GCC error format.") do
@@ -393,6 +405,10 @@ if options.html
   else
     formatters << make_formatter[Rcov::HTMLCoverage]
   end
+end
+
+options.custom_formatters.each do |formatter|
+  formatters << make_formatter[formatter]
 end
 
 textual_formatters = { :counts => Rcov::FullTextReport, :coverage => Rcov::FullTextReport,

--- a/bin/rcov
+++ b/bin/rcov
@@ -180,6 +180,10 @@ EOF
     options.textmode = :coverage
   end
 
+  opts.on("--require LIB", "Require an additional lib before running") do |file|
+	require file
+  end
+
   opts.on("--custom-formatter EXPR", "Generate additional output using a",
           "custom formatter class. The expression",
 		  "is evaluated as Ruby code and should",


### PR DESCRIPTION
I've added some options to allow a custom formatter to be added via command line argument. For example, in my Rails app I've made a lib

```
#{RAILS_ROOT}/lib/cobertura_coverage_formatter.rb
```

(The formatter itself isn't clean enough to contribute back, just a hack to make Bamboo report properly on Rails code coverage)

After this patch, I can add the following lines to rcov.opts, and it works a treat:

```
--require cobertura_coverage_formatter
--custom-formatter CoberturaCoverageFormatter
```
